### PR TITLE
add support for alternative download repos

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,6 +21,7 @@
 # General settings
 default['wordpress']['version'] = "latest"
 default['wordpress']['checksum'] = ""
+default['wordpress']['repourl'] = "http://wordpress.org/"
 default['wordpress']['dir'] = "/var/www/wordpress"
 default['wordpress']['db']['database'] = "wordpressdb"
 default['wordpress']['db']['user'] = "wordpressuser"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -58,7 +58,7 @@ if node['wordpress']['version'] == 'latest'
   end
 else
   remote_file "#{Chef::Config[:file_cache_path]}/wordpress-#{node['wordpress']['version']}.tar.gz" do
-    source "http://wordpress.org/wordpress-#{node['wordpress']['version']}.tar.gz"
+    source "#{node['wordpress']['repourl']}/wordpress-#{node['wordpress']['version']}.tar.gz"
     mode "0644"
   end
 end


### PR DESCRIPTION
Supports building Wordpress servers in an environment behind a firewall.
