### PR TITLE
Allow WPLANG setting to be specified.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Attributes
 
 * `node['wordpress']['version']` - Set the version to download. Using 'latest' (the default) will install the most current version.
 * `node['wordpress']['checksum']` - sha256sum of the tarball, make sure this matches for the version! (Not used for 'latest' version.)
+* `node['wordpress']['language']` - set the language which should be used.
 * `node['wordpress']['dir']` - Set the location to place wordpress files. Default is /var/www.
 * `node['wordpress']['db']['database']` - Wordpress will use this MySQL database to store its data.
 * `node['wordpress']['db']['user']` - Wordpress will connect to MySQL using this user.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,6 +22,7 @@
 default['wordpress']['version'] = "latest"
 default['wordpress']['checksum'] = ""
 default['wordpress']['repourl'] = "http://wordpress.org/"
+default['wordpress']['language'] = ""
 default['wordpress']['dir'] = "/var/www/wordpress"
 default['wordpress']['db']['database'] = "wordpressdb"
 default['wordpress']['db']['user'] = "wordpressuser"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -128,7 +128,8 @@ template "#{node['wordpress']['dir']}/wp-config.php" do
     :auth_key        => node['wordpress']['keys']['auth'],
     :secure_auth_key => node['wordpress']['keys']['secure_auth'],
     :logged_in_key   => node['wordpress']['keys']['logged_in'],
-    :nonce_key       => node['wordpress']['keys']['nonce']
+    :nonce_key       => node['wordpress']['keys']['nonce'],
+    :language        => node['wordpress']['language'],
   )
   notifies :write, "log[wordpress_install_message]"
 end

--- a/templates/default/wp-config.php.erb
+++ b/templates/default/wp-config.php.erb
@@ -64,7 +64,7 @@ $table_prefix  = 'wp_';
  * de.mo to wp-content/languages and set WPLANG to 'de' to enable German
  * language support.
  */
-define ('WPLANG', '');
+define ('WPLANG', '<%= @language %>');
 
 /* That's all, stop editing! Happy blogging. */
 


### PR DESCRIPTION
When installing WordPress from a localized .tar.gz, the language is not set properly by default.
These modifications allow to specify the language to be used.
