### PR TITLE
[COOK-4180] leverage the database cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -14,6 +14,7 @@ recipe "WordPress::languages", "Install WordPress translation files"
 end
 
 depends "apache2", ">= 0.99.4"
+depends "database", ">= 1.6.0"
 depends "mysql", ">= 1.0.5"
 depends "build-essential"
 depends "iis"


### PR DESCRIPTION
Previously, the recipe for adding databases and privileged database
users was reimplementing what is available in the database cookbook.
Therefore, simply add the database cookbook as a dependency and
create the users/databases in a more standard and idempotent fashion.
