### PR TITLE
[COOK-4170] Added docroot variable to account for wordpress/ directory i...

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,9 +59,12 @@ end
 if platform_family?('windows')
   default['wordpress']['parent_dir'] = "#{ENV['SystemDrive']}\\inetpub"
   default['wordpress']['dir'] = "#{node['wordpress']['parent_dir']}\\wordpress"
+  default['wordpress']['docroot'] = node['wordpress']['dir']
   default['wordpress']['url'] = "https://wordpress.org/wordpress-#{node['wordpress']['version']}.zip"
 else
   default['wordpress']['parent_dir'] = '/var/www'
   default['wordpress']['dir'] = "#{node['wordpress']['parent_dir']}/wordpress"
+  # The Wordpress tarball, unpacked into node['wordpress']['dir'], contains a wordpress subdirectory with the web content.
+  default['wordpress']['docroot'] = "#{node['wordpress']['dir']}/wordpress/"
   default['wordpress']['url'] = "https://wordpress.org/wordpress-#{node['wordpress']['version']}.tar.gz"
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -66,7 +66,7 @@ else
 
   execute "extract-wordpress" do
     command "tar xf #{Chef::Config[:file_cache_path]}/#{archive} -C #{node['wordpress']['dir']}"
-    creates "#{node['wordpress']['dir']}/index.php"
+    creates "#{node['wordpress']['dir']}/wordpress/index.php"
   end
 end
 
@@ -102,14 +102,14 @@ if platform?('windows')
   iis_site 'Wordpress' do
     protocol :http
     port 80
-    path node['wordpress']['dir']
+    path node['wordpress']['docroot']
     application_pool 'WordpressPool'
     action [:add,:start]
   end
 else
   web_app "wordpress" do
     template "wordpress.conf.erb"
-    docroot node['wordpress']['dir']
+    docroot node['wordpress']['docroot']
     server_name node['fqdn']
     server_aliases node['wordpress']['server_aliases']
     enable true


### PR DESCRIPTION
...n source tarball, added /wordpress/ to the extract-wordpress creates path so that it doesn't exec each run.
