### PR TITLE
[COOK-4192] Add attribute to control multisite features

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Attributes
 * `node['wordpress']['db']['user']` - Name of the WordPress MySQL user.
 * `node['wordpress']['db']['pass']` - Password of the WordPress MySQL user. By default, generated using openssl cookbook.
 * `node['wordpress']['db']['prefix']` - Prefix of all MySQL tables created by WordPress.
+* `node['wordpress']['allow_multisite']` - Enable [multisite](http://codex.wordpress.org/Create_A_Network) features (default: false).
 
 Usage
 =====

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,6 +31,8 @@ default['wordpress']['db']['pass'] = nil
 default['wordpress']['db']['prefix'] = 'wp_'
 default['wordpress']['db']['host'] = 'localhost'
 
+default['wordpress']['allow_multisite'] = false
+
 default['wordpress']['server_aliases'] = [node['fqdn']]
 
 # Languages

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -85,7 +85,8 @@ template "#{node['wordpress']['dir']}/wp-config.php" do
     :secure_auth_salt => node['wordpress']['salt']['secure_auth'],
     :logged_in_salt   => node['wordpress']['salt']['logged_in'],
     :nonce_salt       => node['wordpress']['salt']['nonce'],
-    :lang             => node['wordpress']['languages']['lang']
+    :lang             => node['wordpress']['languages']['lang'],
+    :allow_multisite  => node['wordpress']['allow_multisite']
   )
   action :create
 end

--- a/templates/default/wp-config.php.erb
+++ b/templates/default/wp-config.php.erb
@@ -80,6 +80,11 @@ define('WPLANG', '<%= @lang %>');
  */
 define('WP_DEBUG', false);
 
+<% if @allow_multisite %>
+/* Multisite */
+define( 'WP_ALLOW_MULTISITE', true );
+<% end %>
+
 /* That's all, stop editing! Happy blogging. */
 
 /** Absolute path to the WordPress directory. */


### PR DESCRIPTION
WordPress includes multisite features for running a network of sites. 
(See http://codex.wordpress.org/Create_A_Network for details.) These 
must be enabled by editing wp-config.php, which is managed by chef when 
using the wordpress cookbook.

This patch adds a boolean attribute, node['wordpress']['allow_multisite'], 
to enable the multisite features.

Fixes: https://tickets.opscode.com/browse/COOK-4192
