### PR TITLE
[COOK-4227] bugfix mysql syntax privileges_exist

### DIFF
--- a/recipes/database.rb
+++ b/recipes/database.rb
@@ -39,7 +39,7 @@ if is_local_host? db['host']
   create_db = %<CREATE DATABASE #{db['name']};>
   db_exists = %<SHOW DATABASES LIKE '#{db['name']}';>
   grant_privileges = %<GRANT ALL PRIVILEGES ON #{db['name']}.* TO #{user};>
-  privileges_exist = %<SHOW GRANTS FOR for #{user}@'%';>
+  privileges_exist = %<SHOW GRANTS FOR '#{db['user']}'@'#{db['host']}';>
   flush_privileges = %<FLUSH PRIVILEGES;>
 
   execute "Create WordPress MySQL User" do


### PR DESCRIPTION
Small change to fix the mysql syntax error:
ERROR 1064 (42000) at line 1: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'for 'username'@'127.0.0.1'@'%'' at line 1
The error means the only_if in execute "Grant WordPress MySQL Privileges" will always be empty, so the execute will always run.
