### PR TITLE
[COOK-4354] s/Wordpress/WordPress/g in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 Contribution Guidelines
 =======================
 
-If you would like to contribute to the Chef Wordpress cookbook,
+If you would like to contribute to the Chef WordPress cookbook,
 you must open a ticket in [JIRA](http://tickets.opscode.com).
 
 1. Create the ticket in the [COOK] (use "wordpress" for the component)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Description
 ===========
 
-The Chef Wordpress cookbook installs and configures Wordpress according to the instructions at http://codex.wordpress.org/Installing_WordPress.
+The Chef WordPress cookbook installs and configures WordPress according to the instructions at http://codex.wordpress.org/Installing_WordPress.
 
 Description
 ===========


### PR DESCRIPTION
Updates naming in `README.md` and `CONTRIBUTING.md` to match proper casing.
