### PR TITLE
Make server_name configurable via attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -63,6 +63,7 @@ if node['platform'] == 'windows'
   default['wordpress']['dir'] = "#{node['wordpress']['parent_dir']}\\wordpress"
   default['wordpress']['url'] = "https://wordpress.org/wordpress-#{node['wordpress']['version']}.zip"
 else
+  default['wordpress']['server_name'] = node['fqdn']
   default['wordpress']['parent_dir'] = '/var/www'
   default['wordpress']['dir'] = "#{node['wordpress']['parent_dir']}/wordpress"
   default['wordpress']['url'] = "https://wordpress.org/wordpress-#{node['wordpress']['version']}.tar.gz"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -114,7 +114,7 @@ else
   web_app "wordpress" do
     template "wordpress.conf.erb"
     docroot node['wordpress']['dir']
-    server_name node['fqdn']
+    server_name node['wordpress']['server_name']
     server_aliases node['wordpress']['server_aliases']
     server_port node['apache']['listen_ports']
     enable true


### PR DESCRIPTION
This allows the ServerName directive in the Apache virtualhost template to be configurable via attribute, but defaults to node['fqdn'] for compatibility.
