### PR TITLE
Use port 80 by default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,6 +34,7 @@ default['wordpress']['db']['host'] = 'localhost'
 default['wordpress']['allow_multisite'] = false
 
 default['wordpress']['server_aliases'] = [node['fqdn']]
+default['wordpress']['server_port'] = '80'
 
 default['wordpress']['install']['user'] = node['apache']['user']
 default['wordpress']['install']['group'] = node['apache']['group']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -116,7 +116,7 @@ else
     docroot node['wordpress']['dir']
     server_name node['wordpress']['server_name']
     server_aliases node['wordpress']['server_aliases']
-    server_port node['apache']['listen_ports']
+    server_port node['wordpress']['server_port']
     enable true
   end
 end

--- a/templates/default/wordpress.conf.erb
+++ b/templates/default/wordpress.conf.erb
@@ -1,4 +1,4 @@
-<VirtualHost *:<% @params[:server_port].each do |a| %><%= a %> <% end %> >
+<VirtualHost *:<%= @params[:server_port] %>>
   ServerName <%= @params[:server_name] %>
   ServerAlias <% @params[:server_aliases].each do |a| %><%= a %> <% end %>
   DocumentRoot <%= @params[:docroot] %>


### PR DESCRIPTION
Tying WordPress to all of Apache's listen ports by default is not desirable as you may want other apps on other ports. In addition, Apache's default listen ports are 80 and 443 and the current behavior of this cookbook  attempts to create a VirtualHost directive like this:

```
<VirtualHost *:80 443  >
```

which is not valid syntax and causes an error.

This patch still allows wrapper cookbooks to specify listen ports for WordPress, but also adds a sane default of port `80`.
