### PR TITLE
Attributes for database charset and collation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Attributes
 * `node['wordpress']['db']['user']` - Name of the WordPress MySQL user.
 * `node['wordpress']['db']['pass']` - Password of the WordPress MySQL user. By default, generated using openssl cookbook.
 * `node['wordpress']['db']['prefix']` - Prefix of all MySQL tables created by WordPress.
+* `node['wordpress']['db']['charset']` - [Character set](http://dev.mysql.com/doc/refman/5.7/en/charset-charsets.html) of the WordPress MySQL database tables. Defaults to 'utf8'.
+* `node['wordpress']['db']['collate']` - [Collation](http://dev.mysql.com/doc/refman/5.7/en/charset-collation-effect.html) of the WordPress MySQL database tables.
 * `node['wordpress']['allow_multisite']` - Enable [multisite](http://codex.wordpress.org/Create_A_Network) features (default: false).
 
 Usage

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,6 +30,8 @@ default['wordpress']['db']['user'] = "wordpressuser"
 default['wordpress']['db']['pass'] = nil
 default['wordpress']['db']['prefix'] = 'wp_'
 default['wordpress']['db']['host'] = 'localhost'
+default['wordpress']['db']['charset'] = 'utf8'
+default['wordpress']['db']['collate'] = ''
 
 default['wordpress']['allow_multisite'] = false
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -78,6 +78,8 @@ template "#{node['wordpress']['dir']}/wp-config.php" do
     :db_password      => node['wordpress']['db']['pass'],
     :db_host          => node['wordpress']['db']['host'],
     :db_prefix        => node['wordpress']['db']['prefix'],
+    :db_charset       => node['wordpress']['db']['charset'],
+    :db_collate       => node['wordpress']['db']['collate'],
     :auth_key         => node['wordpress']['keys']['auth'],
     :secure_auth_key  => node['wordpress']['keys']['secure_auth'],
     :logged_in_key    => node['wordpress']['keys']['logged_in'],

--- a/templates/default/wp-config.php.erb
+++ b/templates/default/wp-config.php.erb
@@ -28,10 +28,10 @@ define('DB_PASSWORD', '<%= @db_password %>');
 define('DB_HOST', '<%= @db_host %>');
 
 /** Database Charset to use in creating database tables. */
-define('DB_CHARSET', 'utf8');
+define('DB_CHARSET', '<%= @db_charset %>');
 
 /** The Database Collate type. Don't change this if in doubt. */
-define('DB_COLLATE', '');
+define('DB_COLLATE', '<%= @db_collate %>');
 
 /**#@+
  * Authentication Unique Keys and Salts.


### PR DESCRIPTION
I wish to be able to override the default collation. This patch also includes an attribute for the charset, so that every DB option in wp-config.php.erb can be configured using attributes.
