### PR TITLE
Restore missing db_charset and db_collate to nginx recipe.

### DIFF
--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -82,6 +82,8 @@ template "#{node['wordpress']['dir']}/wp-config.php" do
     :db_password      => node['wordpress']['db']['pass'],
     :db_host          => node['wordpress']['db']['host'],
     :db_prefix        => node['wordpress']['db']['prefix'],
+    :db_charset       => node['wordpress']['db']['charset'],
+    :db_collate       => node['wordpress']['db']['collate'],
     :auth_key         => node['wordpress']['keys']['auth'],
     :secure_auth_key  => node['wordpress']['keys']['secure_auth'],
     :logged_in_key    => node['wordpress']['keys']['logged_in'],


### PR DESCRIPTION
I was having an issue with charset and noticed it wasn't being set in wp-config.php. Upon further investigation, it looks like you're not sending the variables to the template in the nginx recipe. Putting them back in fixed the issues I was saying. Maybe these were left out for a reason?
