### PR TITLE
Added guard to tar extraction so we only grab Wordpress on first run

### DIFF
--- a/recipes/app.rb
+++ b/recipes/app.rb
@@ -57,6 +57,7 @@ else
     user node['wordpress']['install']['user']
     group node['wordpress']['install']['group']
     tar_flags [ '--strip-components 1' ]
+    not_if { ::File.exists?("#{node['wordpress']['dir']}/index.php") }
   end
 end
 


### PR DESCRIPTION
I had some failed chef-client runs today because the the wordpress site wasn't responding, and realized that the guard was there for Windows but not *nix. Fixed.
