### PR TITLE
Added output of wp-config options as key value pairs from a hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Attributes
 * `node['wordpress']['db']['charset']` - [Character set](http://dev.mysql.com/doc/refman/5.7/en/charset-charsets.html) of the WordPress MySQL database tables. Defaults to 'utf8'.
 * `node['wordpress']['db']['collate']` - [Collation](http://dev.mysql.com/doc/refman/5.7/en/charset-collation-effect.html) of the WordPress MySQL database tables.
 * `node['wordpress']['allow_multisite']` - Enable [multisite](http://codex.wordpress.org/Create_A_Network) features (default: false).
+* `node['wordpress']['wp_config_options']` - A hash of options to define in wp_config.php. Emitted as key value pairs: `define( '<%= @name %>', <%= @value %> );`. Note, you will need to quote text but omit quotes for true/false and numbers. (default: {}).
 * `node['wordpress']['config_perms']` - Permissions to set for a site's wp-config.php.
 
 Usage

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,6 +35,8 @@ default['wordpress']['db']['collate'] = ''
 
 default['wordpress']['allow_multisite'] = false
 
+default['wordpress']['wp_config_options'] = {}
+
 default['wordpress']['config_perms'] = 0644
 default['wordpress']['server_aliases'] = [node['fqdn']]
 default['wordpress']['server_port'] = '80'

--- a/recipes/app.rb
+++ b/recipes/app.rb
@@ -65,23 +65,24 @@ template "#{node['wordpress']['dir']}/wp-config.php" do
   source 'wp-config.php.erb'
   mode node['wordpress']['config_perms']
   variables(
-    :db_name          => node['wordpress']['db']['name'],
-    :db_user          => node['wordpress']['db']['user'],
-    :db_password      => node['wordpress']['db']['pass'],
-    :db_host          => node['wordpress']['db']['host'],
-    :db_prefix        => node['wordpress']['db']['prefix'],
-    :db_charset       => node['wordpress']['db']['charset'],
-    :db_collate       => node['wordpress']['db']['collate'],
-    :auth_key         => node['wordpress']['keys']['auth'],
-    :secure_auth_key  => node['wordpress']['keys']['secure_auth'],
-    :logged_in_key    => node['wordpress']['keys']['logged_in'],
-    :nonce_key        => node['wordpress']['keys']['nonce'],
-    :auth_salt        => node['wordpress']['salt']['auth'],
-    :secure_auth_salt => node['wordpress']['salt']['secure_auth'],
-    :logged_in_salt   => node['wordpress']['salt']['logged_in'],
-    :nonce_salt       => node['wordpress']['salt']['nonce'],
-    :lang             => node['wordpress']['languages']['lang'],
-    :allow_multisite  => node['wordpress']['allow_multisite']
+    :db_name           => node['wordpress']['db']['name'],
+    :db_user           => node['wordpress']['db']['user'],
+    :db_password       => node['wordpress']['db']['pass'],
+    :db_host           => node['wordpress']['db']['host'],
+    :db_prefix         => node['wordpress']['db']['prefix'],
+    :db_charset        => node['wordpress']['db']['charset'],
+    :db_collate        => node['wordpress']['db']['collate'],
+    :auth_key          => node['wordpress']['keys']['auth'],
+    :secure_auth_key   => node['wordpress']['keys']['secure_auth'],
+    :logged_in_key     => node['wordpress']['keys']['logged_in'],
+    :nonce_key         => node['wordpress']['keys']['nonce'],
+    :auth_salt         => node['wordpress']['salt']['auth'],
+    :secure_auth_salt  => node['wordpress']['salt']['secure_auth'],
+    :logged_in_salt    => node['wordpress']['salt']['logged_in'],
+    :nonce_salt        => node['wordpress']['salt']['nonce'],
+    :lang              => node['wordpress']['languages']['lang'],
+    :allow_multisite   => node['wordpress']['allow_multisite'],
+    :wp_config_options => node['wordpress']['wp_config_options']
   )
   owner node['wordpress']['install']['user']
   group node['wordpress']['install']['group']

--- a/templates/default/wp-config.php.erb
+++ b/templates/default/wp-config.php.erb
@@ -85,6 +85,10 @@ define('WP_DEBUG', false);
 define( 'WP_ALLOW_MULTISITE', true );
 <% end %>
 
+<% @wp_config_options.each do |key,value| %>
+define( '<%= key %>', <%= value %> );
+<% end %>
+
 /* That's all, stop editing! Happy blogging. */
 
 /** Absolute path to the WordPress directory. */


### PR DESCRIPTION
Adds an attribute wp_config_options to allow addition of any required configuration in wp-config.php 

A possible solution to #47.

For example

```json
"wordpress": {
  "allow_multisite": true,
  "wp_config_options": {
    "MULTISITE": "true",
    "SUBDOMAIN_INSTALL": "true",
    "DOMAIN_CURRENT_SITE": "'example.com'",
    "PATH_CURRENT_SITE": "'/'",
    "SITE_ID_CURRENT_SITE": "1",
    "BLOG_ID_CURRENT_SITE": "1",
    "SUNRISE": "1",
    "WP_CACHE": "true"
  }
}
```

outputs

```php
/* Multisite */
define( 'WP_ALLOW_MULTISITE', true );

define( 'MULTISITE', true );
define( 'SUBDOMAIN_INSTALL', true );
define( 'DOMAIN_CURRENT_SITE', 'example.com' );
define( 'PATH_CURRENT_SITE', '/' );
define( 'SITE_ID_CURRENT_SITE', 1 );
define( 'BLOG_ID_CURRENT_SITE', 1 );
define( 'SUNRISE', 1 );
define( 'WP_CACHE', true );
```

