### PR TITLE
Apache SSL Support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -31,8 +31,10 @@ suites:
         server_root_password: "Please-Dont-Use-In-Production"
         server_debian_password: "Please-Dont-Use-In-Production"
         server_repl_password: "Please-Dont-Use-In-Production"
+      apache2:
+        version: "2.4"
       wordpress:
-        use_ssl: true
+        use_ssl: false
         ssl:
           country: "US"
           state: "Texas"

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -2,6 +2,9 @@ driver_plugin: vagrant
 driver_config:
   require_chef_omnibus: true
 
+provisioner:
+  name: chef_zero
+
 platforms:
   - name: ubuntu-10.04
     run_list:
@@ -10,6 +13,10 @@ platforms:
     run_list:
       - recipe[apt]
   - name: ubuntu-14.04
+    driver_config:
+      network:
+      - ["forwarded_port", {guest: 80, host: 8080}]
+      - ["forwarded_port", {guest: 443, host: 8443}]
     run_list:
       - recipe[apt]
   - name: centos-6.5
@@ -24,6 +31,14 @@ suites:
         server_root_password: "Please-Dont-Use-In-Production"
         server_debian_password: "Please-Dont-Use-In-Production"
         server_repl_password: "Please-Dont-Use-In-Production"
+      wordpress:
+        use_ssl: true
+        ssl:
+          country: "US"
+          state: "Texas"
+          city: "Houston"
+          organization: "Foo Inc."
+          email: "foo@example.com"
   - name: nginx
     run_list:
       - recipe[wordpress::nginx]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -87,7 +87,8 @@ else
   default['wordpress']['server_name'] = node['fqdn']
   default['wordpress']['parent_dir'] = '/var/www'
   default['wordpress']['dir'] = "#{node['wordpress']['parent_dir']}/wordpress"
-  default['wordpress']['url'] = "https://wordpress.org/wordpress-#{node['wordpress']['version']}.tar.gz"
+  default['wordpress']['repo']['url'] = "https://github.com/WordPress/WordPress.git"
+  default['wordpress']['repo']['branch'] = "4.0-branch"
 end
 
 default['wordpress']['php_options'] = { 'php_admin_value[upload_max_filesize]' => '50M', 'php_admin_value[post_max_size]' => '55M' }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,7 +37,21 @@ default['wordpress']['allow_multisite'] = false
 
 default['wordpress']['config_perms'] = 0644
 default['wordpress']['server_aliases'] = [node['fqdn']]
-default['wordpress']['server_port'] = '80'
+default['wordpress']['http_port'] = '80'
+default['wordpress']['https_port'] = '443'
+default['wordpress']['allow_override'] = 'FileInfo Options'
+
+# SSL Options
+default['wordpress']['use_ssl'] = false
+default['wordpress']['ssl']['protocol'] = 'all -SSLv2 -SSLv3'
+default['wordpress']['ssl']['common_name'] = node['fqdn']
+default['wordpress']['ssl']["country"] = nil
+default['wordpress']['ssl']["state"] = nil
+default['wordpress']['ssl']["city"] = nil
+default['wordpress']['ssl']["organization"] = nil
+default['wordpress']['ssl']["department"] = nil
+default['wordpress']['ssl']["email"] = nil
+
 
 default['wordpress']['install']['user'] = node['apache']['user']
 default['wordpress']['install']['group'] = node['apache']['group']

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,8 @@ recipe "WordPress::languages", "Install WordPress translation files"
   depends cb
 end
 
-depends "apache2", ">= 2.0.0"
+depends "apache2", ">= 3.0.0"
+depends "ssl_certificate", "~> 0.4.0"
 depends "database", ">= 1.6.0"
 depends "mysql", ">= 5.0.0"
 depends "mysql-chef_gem", ">= 0.0.2"

--- a/recipes/apache.rb
+++ b/recipes/apache.rb
@@ -4,29 +4,30 @@
 #
 # Copyright 2009-2010, Opscode, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the License is distributed on an 'AS IS' BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
 
-include_recipe "php"
+include_recipe 'php'
 
 # On Windows PHP comes with the MySQL Module and we use IIS on Windows
-unless platform? "windows"
-  include_recipe "php::module_mysql"
-  include_recipe "apache2"
-  include_recipe "apache2::mod_php5"
+unless platform? 'windows'
+  include_recipe 'php::module_mysql'
+  include_recipe 'apache2'
+  include_recipe 'apache2::mod_php5'
+  include_recipe "apache2::mod_ssl"
 end
 
-include_recipe "wordpress::app"
+include_recipe 'wordpress::app'
 
 if platform?('windows')
 
@@ -45,12 +46,30 @@ if platform?('windows')
     action [:add,:start]
   end
 else
-  web_app "wordpress" do
-    template "wordpress.conf.erb"
-    docroot node['wordpress']['dir']
-    server_name node['wordpress']['server_name']
-    server_aliases node['wordpress']['server_aliases']
-    server_port node['wordpress']['server_port']
-    enable true
+  if node['wordpress']['use_ssl']
+
+    cert = ssl_certificate "wordpress" do
+      namespace node["wordpress"]['ssl']
+      notifies :restart, "service[apache2]"
+    end
+
+    web_app 'wordpress-ssl' do
+      template 'wordpress-ssl.conf.erb'
+      docroot node['wordpress']['dir']
+      server_name cert.common_name
+      server_aliases node['wordpress']['server_aliases']
+      ssl_cert cert.cert_path
+      ssl_key cert.key_path
+      enable true
+    end
+  else
+    web_app 'wordpress' do
+      template 'wordpress.conf.erb'
+      docroot node['wordpress']['dir']
+      server_name node['wordpress']['server_name']
+      server_aliases node['wordpress']['server_aliases']
+      allow_override node['wordpress']['allow_override']
+      enable true
+    end
   end
 end

--- a/recipes/app.rb
+++ b/recipes/app.rb
@@ -51,13 +51,12 @@ if platform_family?('windows')
     not_if {::File.exists?("#{node['wordpress']['dir']}\\index.php")}
   end
 else
-  tar_extract node['wordpress']['url'] do
-    target_dir node['wordpress']['dir']
-    creates File.join(node['wordpress']['dir'], 'index.php')
+  git node['wordpress']['dir'] do
+    repository node['wordpress']['repo']['url']
+    revision node['wordpress']['repo']['branch']
     user node['wordpress']['install']['user']
     group node['wordpress']['install']['group']
-    tar_flags [ '--strip-components 1' ]
-    not_if { ::File.exists?("#{node['wordpress']['dir']}/index.php") }
+    action :sync
   end
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,4 +17,5 @@
 # limitations under the License.
 #
 
+include_recipe "wordpress::package"
 include_recipe "wordpress::apache"

--- a/templates/default/wordpress-ssl.conf.erb
+++ b/templates/default/wordpress-ssl.conf.erb
@@ -1,4 +1,4 @@
-<VirtualHost *:<%= node['wordpress']['http_port'] %>>
+<VirtualHost *:<%= node['wordpress']['https_port'] %>>
   ServerName <%= @params[:server_name] %>
   ServerAlias <% @params[:server_aliases].each do |a| %><%= a %> <% end %>
   DocumentRoot <%= @params[:docroot] %>
@@ -15,22 +15,22 @@
   </Directory>
 
   <Directory />
-  Options FollowSymLinks
-  AllowOverride None
-</Directory>
+    Options FollowSymLinks
+    AllowOverride None
+  </Directory>
 
-<Location /server-status>
-  SetHandler server-status
+  <Location /server-status>
+    SetHandler server-status
 
   <% if node['apache']['version'] == '2.4' -%>
-  Require local
+    Require local
   <% else -%>
-  Order Deny,Allow
-  Deny from all
-  Allow from 127.0.0.1
+    Order Deny,Allow
+    Deny from all
+    Allow from 127.0.0.1
   <% end -%>
 
-</Location>
+  </Location>
 
   LogLevel info
   ErrorLog <%= node['apache']['log_dir'] %>/<%= @params[:name] %>-error.log
@@ -41,4 +41,9 @@
   RewriteLog <%= node['apache']['log_dir'] %>/<%= @application_name %>-rewrite.log
   RewriteLogLevel 0
 <% end %>
+
+  SSLEngine on
+  SSLCertificateFile <%= @params[:ssl_cert] %>
+  SSLCertificateKeyFile <%= @params[:ssl_key] %>
+
 </VirtualHost>

--- a/test/integration/default/bats/verify_default.bats
+++ b/test/integration/default/bats/verify_default.bats
@@ -1,4 +1,7 @@
-@test "check for wordpress install" {
-  export welcome="Welcome to the famous five minute WordPress installation process"
-  wget -O - http://localhost/wp-admin/install.php | grep "${welcome}"
+@test "check for wordpress install on port 80" {
+  run bash -c "wget -O - http://localhost:8080 | grep 'WordPress'"
+}
+
+@test "check for wordpress install on port 443" {
+  run bash -c "wget --no-check-certificate -O - http://localhost:8443 | grep 'Houston'"
 }


### PR DESCRIPTION
- This change adds a dependency on the ssl certificate cookbook.
- Updated apache2 cookbook dependency (fixes POODLE)
- If an SSL cert is not present, a self-signed cert will be generated.
- Apache will be configured to use both ssl and non-ssl for compatibility.
- Added integration tests (and fixed old one).
- Updated test kitchen rules to test SSL
