### PR TITLE
Do not force inclusion of database recipe in app recipe.

### DIFF
--- a/recipes/app.rb
+++ b/recipes/app.rb
@@ -17,8 +17,6 @@
 # limitations under the License.
 #
 
-include_recipe "wordpress::database"
-
 ::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
 node.set_unless['wordpress']['keys']['auth'] = secure_password
 node.set_unless['wordpress']['keys']['secure_auth'] = secure_password


### PR DESCRIPTION
This may go against the one stop setup for this cookbook, but for folks who may already be configuring their own mysql_service resource for the database, forcing the inclusion of the database recipe from this cookbook is very inflexible.  Given that the database recipe doesn't allow any configuration to the mysql_service resource I feel that one should have to add wordpress:database to their run list if they truly want this cookbook to setup their DB.
