### PR TITLE
Do not force database recipe in app creation. Should be added to run …

### DIFF
--- a/recipes/app.rb
+++ b/recipes/app.rb
@@ -17,8 +17,6 @@
 # limitations under the License.
 #
 
-include_recipe "wordpress::database"
-
 ::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
 node.set_unless['wordpress']['keys']['auth'] = secure_password
 node.set_unless['wordpress']['keys']['secure_auth'] = secure_password


### PR DESCRIPTION
…list before including app recipe.

Basically, this should be left to the person configuring the run list.  One example where this does not work is if one is using an external database like Amazon RDS.  You should not force installation and setup of MySQL server for anyone wanting to use the app recipe.
