### PR TITLE
Bumped up php-fpm version.  'Tar' cookbook dependency replaced with 'Ark' due to inactvity.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -21,7 +21,7 @@ depends "build-essential"
 depends "iis", ">= 1.6.2"
 depends "tar", ">= 0.3.1"
 depends "nginx", "~> 2.7.4"
-depends "php-fpm", "~> 0.6.10"
+depends "php-fpm", ">= 0.6.10"
 depends 'selinux', '~> 0.7'
 
 %w{ debian ubuntu windows centos redhat scientific oracle }.each do |os|

--- a/metadata.rb
+++ b/metadata.rb
@@ -19,7 +19,7 @@ depends "mysql", ">= 6.0"
 depends "mysql2_chef_gem", "~> 1.0.1"
 depends "build-essential"
 depends "iis", ">= 1.6.2"
-depends "tar", ">= 0.3.1"
+depends "ark", "~> 0.9.0"
 depends "nginx", "~> 2.7.4"
 depends "php-fpm", ">= 0.6.10"
 depends 'selinux', '~> 0.7'

--- a/recipes/app.rb
+++ b/recipes/app.rb
@@ -51,13 +51,14 @@ if platform_family?('windows')
     not_if {::File.exists?("#{node['wordpress']['dir']}\\index.php")}
   end
 else
-  tar_extract node['wordpress']['url'] do
-    target_dir node['wordpress']['dir']
+  ark "wordpress" do
+    url node['wordpress']['url']
+    path node['wordpress']['parent_dir']
     creates File.join(node['wordpress']['dir'], 'index.php')
-    user node['wordpress']['install']['user']
+    owner node['wordpress']['install']['user']
     group node['wordpress']['install']['group']
-    tar_flags [ '--strip-components 1' ]
-    not_if { ::File.exists?("#{node['wordpress']['dir']}/index.php") }
+    strip_components 1
+    action :put
   end
 end
 


### PR DESCRIPTION
wordpress-cookbook has been successfully tested with php-fpm cookbook 0.7.0.

The 'Tar' cookbook has been marked as inactive.  'Ark' provides similar functionality.
