### PR TITLE
Make the cookbook easier to wrap

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -101,3 +101,12 @@ else
 end
 
 default['wordpress']['php_options'] = { 'php_admin_value[upload_max_filesize]' => '50M', 'php_admin_value[post_max_size]' => '55M' }
+
+default['wordpress']['keys']['auth'] = nil
+default['wordpress']['keys']['secure_auth'] = nil
+default['wordpress']['keys']['logged_in'] = nil
+default['wordpress']['keys']['nonce'] = nil
+default['wordpress']['salt']['auth'] = nil
+default['wordpress']['salt']['secure_auth'] = nil
+default['wordpress']['salt']['logged_in'] = nil
+default['wordpress']['salt']['nonce'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,6 +35,7 @@ default['wordpress']['db']['host'] = 'localhost'
 default['wordpress']['db']['port'] = '3306'  # Must be a string
 default['wordpress']['db']['charset'] = 'utf8'
 default['wordpress']['db']['collate'] = ''
+default['wordpress']['db']['install'] = true
 case node['platform']
 when 'ubuntu'
   case node['platform_version']

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -24,6 +24,8 @@ module Wordpress
     def is_local_host?(host)
       if host == 'localhost' || host == '127.0.0.1' || host == '::1'
         true
+      elsif host =~ /\A\w*:.*\z/
+        false
       else
         require 'socket'
         require 'resolv'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -22,10 +22,8 @@
 module Wordpress
   module Helpers
     def is_local_host?(host)
-      if host == 'localhost' || host == '127.0.0.1' || host == '::1'
+      if host == 'localhost' || host == '127.0.0.1' || host == '::1' || host =~ /\Alocalhost:.*\z/
         true
-      elsif host =~ /\A\w*:.*\z/
-        false
       else
         require 'socket'
         require 'resolv'

--- a/recipes/app.rb
+++ b/recipes/app.rb
@@ -20,14 +20,14 @@
 include_recipe "wordpress::database"
 
 ::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
-node.default['wordpress']['keys']['auth'] = secure_password unless node['wordpress']['keys']['auth']
-node.default['wordpress']['keys']['secure_auth'] = secure_password unless node['wordpress']['keys']['secure_auth']
-node.default['wordpress']['keys']['logged_in'] = secure_password unless node['wordpress']['keys']['logged_in']
-node.default['wordpress']['keys']['nonce'] = secure_password unless node['wordpress']['keys']['nonce']
-node.default['wordpress']['salt']['auth'] = secure_password unless node['wordpress']['salt']['auth']
-node.default['wordpress']['salt']['secure_auth'] = secure_password unless node['wordpress']['salt']['secure_auth']
-node.default['wordpress']['salt']['logged_in'] = secure_password unless node['wordpress']['salt']['logged_in']
-node.default['wordpress']['salt']['nonce'] = secure_password unless node['wordpress']['salt']['nonce']
+node.normal['wordpress']['keys']['auth'] = secure_password unless node['wordpress']['keys']['auth']
+node.normal['wordpress']['keys']['secure_auth'] = secure_password unless node['wordpress']['keys']['secure_auth']
+node.normal['wordpress']['keys']['logged_in'] = secure_password unless node['wordpress']['keys']['logged_in']
+node.normal['wordpress']['keys']['nonce'] = secure_password unless node['wordpress']['keys']['nonce']
+node.normal['wordpress']['salt']['auth'] = secure_password unless node['wordpress']['salt']['auth']
+node.normal['wordpress']['salt']['secure_auth'] = secure_password unless node['wordpress']['salt']['secure_auth']
+node.normal['wordpress']['salt']['logged_in'] = secure_password unless node['wordpress']['salt']['logged_in']
+node.normal['wordpress']['salt']['nonce'] = secure_password unless node['wordpress']['salt']['nonce']
 node.save unless Chef::Config[:solo]
 
 directory node['wordpress']['dir'] do

--- a/recipes/app.rb
+++ b/recipes/app.rb
@@ -20,14 +20,14 @@
 include_recipe "wordpress::database"
 
 ::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
-node.set_unless['wordpress']['keys']['auth'] = secure_password
-node.set_unless['wordpress']['keys']['secure_auth'] = secure_password
-node.set_unless['wordpress']['keys']['logged_in'] = secure_password
-node.set_unless['wordpress']['keys']['nonce'] = secure_password
-node.set_unless['wordpress']['salt']['auth'] = secure_password
-node.set_unless['wordpress']['salt']['secure_auth'] = secure_password
-node.set_unless['wordpress']['salt']['logged_in'] = secure_password
-node.set_unless['wordpress']['salt']['nonce'] = secure_password
+node.default['wordpress']['keys']['auth'] = secure_password unless node['wordpress']['keys']['auth']
+node.default['wordpress']['keys']['secure_auth'] = secure_password unless node['wordpress']['keys']['secure_auth']
+node.default['wordpress']['keys']['logged_in'] = secure_password unless node['wordpress']['keys']['logged_in']
+node.default['wordpress']['keys']['nonce'] = secure_password unless node['wordpress']['keys']['nonce']
+node.default['wordpress']['salt']['auth'] = secure_password unless node['wordpress']['salt']['auth']
+node.default['wordpress']['salt']['secure_auth'] = secure_password unless node['wordpress']['salt']['secure_auth']
+node.default['wordpress']['salt']['logged_in'] = secure_password unless node['wordpress']['salt']['logged_in']
+node.default['wordpress']['salt']['nonce'] = secure_password unless node['wordpress']['salt']['nonce']
 node.save unless Chef::Config[:solo]
 
 directory node['wordpress']['dir'] do

--- a/recipes/database.rb
+++ b/recipes/database.rb
@@ -37,7 +37,7 @@ node.save unless Chef::Config[:solo]
 
 db = node['wordpress']['db']
 
-if is_local_host? db['host']
+if is_local_host? db['host'] and db['install']
 
   # The following is required for the mysql community cookbook to work properly
   include_recipe 'selinux::disabled' if node['platform_family'] == 'rhel'

--- a/recipes/database.rb
+++ b/recipes/database.rb
@@ -32,7 +32,7 @@ end
 ::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
 ::Chef::Recipe.send(:include, Wordpress::Helpers)
 
-node.set_unless['wordpress']['db']['pass'] = secure_password
+node.default['wordpress']['db']['pass'] = secure_password unless node['wordpress']['db']['pass']
 node.save unless Chef::Config[:solo]
 
 db = node['wordpress']['db']

--- a/recipes/database.rb
+++ b/recipes/database.rb
@@ -32,7 +32,7 @@ end
 ::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
 ::Chef::Recipe.send(:include, Wordpress::Helpers)
 
-node.default['wordpress']['db']['pass'] = secure_password unless node['wordpress']['db']['pass']
+node.normal['wordpress']['db']['pass'] = secure_password unless node['wordpress']['db']['pass']
 node.save unless Chef::Config[:solo]
 
 db = node['wordpress']['db']

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-node.set_unless['php-fpm']['pools'] = []
+node.default['php-fpm']['pools'] = [] unless node['php-fpm']['pools']
 
 include_recipe "php-fpm"
 
@@ -36,7 +36,7 @@ end
 
 include_recipe "php::module_mysql"
 
-node.set_unless['nginx']['default_site_enabled'] = false
+node.default['nginx']['default_site_enabled'] = false unless node['nginx']['default_site_enabled']
 include_recipe "nginx"
 
 include_recipe "wordpress::app"

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-node.default['php-fpm']['pools'] = [] unless node['php-fpm']['pools']
+node.normal['php-fpm']['pools'] = [] unless node['php-fpm']['pools']
 
 include_recipe "php-fpm"
 
@@ -36,7 +36,7 @@ end
 
 include_recipe "php::module_mysql"
 
-node.default['nginx']['default_site_enabled'] = false unless node['nginx']['default_site_enabled']
+node.normal['nginx']['default_site_enabled'] = false unless node['nginx']['default_site_enabled']
 include_recipe "nginx"
 
 include_recipe "wordpress::app"


### PR DESCRIPTION
The following changes make it easier to wrap the wordpress cookbook and control its behaviour:
1. `node.set_unless` doesn't do what you might think it does (http://tickets.opscode.com/browse/CHEF-2945), and setting normal attributes makes things awkward. This PR changes the use of set_unless to a guard clause which means that a normal attribute will only be set if no other type of attribute is set. A wrapper cookbook can E.g. load the attribute values from a vault item and set them as default attributes, without having them persist into the node attributes or be over-written by set_unless.
2. Add the `node['wordpress']['db']['install']` attribute that allows the wrapper to control the MySQL installation. For example I'm installing into a cloud (GCE) instance and wish to use the GCE MySQL instance via. a socket, so I don't need a local MySQL instance and can set the attribute to `false` to disable it entirely.
3. A small fix to the `is_local_host?` helper that allows it to recognise UNIX sockets in the form `localhost:/path/to/socket`
