### PR TITLE
allow wp to be hosted in a nested directory

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -101,3 +101,4 @@ else
 end
 
 default['wordpress']['php_options'] = { 'php_admin_value[upload_max_filesize]' => '50M', 'php_admin_value[post_max_size]' => '55M' }
+default['wordpress']['webroot'] = node['wordpress']['dir']

--- a/recipes/apache.rb
+++ b/recipes/apache.rb
@@ -40,14 +40,14 @@ if platform?('windows')
   iis_site 'Wordpress' do
     protocol :http
     port 80
-    path node['wordpress']['dir']
+    path node['wordpress']['webroot']
     application_pool 'WordpressPool'
     action [:add,:start]
   end
 else
   web_app "wordpress" do
     template "wordpress.conf.erb"
-    docroot node['wordpress']['dir']
+    docroot node['wordpress']['webroot']
     server_name node['wordpress']['server_name']
     server_aliases node['wordpress']['server_aliases']
     server_port node['wordpress']['server_port']

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -44,7 +44,7 @@ include_recipe "wordpress::app"
 template "#{node['nginx']['dir']}/sites-enabled/wordpress.conf" do
   source "nginx.conf.erb"
   variables(
-    :docroot          => node['wordpress']['dir'],
+    :docroot          => node['wordpress']['webroot'],
     :server_name      => node['wordpress']['server_name'],
     :server_aliases   => node['wordpress']['server_aliases'],
     :server_port      => node['wordpress']['server_port']


### PR DESCRIPTION
Create a new attribute that can be overridden which would allow WP to be hosted not in the webdoc root. This is useful if you want to embed wp in a different folder than / of your site
